### PR TITLE
Drop completely NA columns from data

### DIFF
--- a/src/hdx/scraper/cod_population/cod_population.py
+++ b/src/hdx/scraper/cod_population/cod_population.py
@@ -135,6 +135,7 @@ class CODPopulation:
                 resource["name"], "utf-8"
             )
             csv_data = read_csv(filepath, encoding=encoding)
+            csv_data.dropna(axis=1, how="all", inplace=True)
             data[admin_level] = csv_data
 
         return missing_levels, data


### PR DESCRIPTION
Null admin names causing an issue in CMR. This drops columns from the input data that have only null values so the script can pull alternatives like names in other languages.